### PR TITLE
[BAHAMUT] [Q-MR1] Fix ULL and headset voice calls

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -2520,6 +2520,10 @@
         <path name="voice-headphones" />
     </path>
 
+    <path name="voice-headset">
+        <path name="voice-headphones" />
+    </path>
+
     <path name="voice-headset-mic">
         <path name="headset-mic" />
     </path>

--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -827,7 +827,7 @@
     </path>
 
     <path name="audio-ull-playback">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia8" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback speaker-protected">
@@ -835,7 +835,7 @@
     </path>
 
     <path name="audio-ull-playback headphones">
-        <path name="audio-ull-playback" />
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback speaker-and-headphones">
@@ -844,7 +844,7 @@
     </path>
 
     <path name="audio-ull-playback display-port">
-        <ctl name="DISPLAY_PORT Mixer MultiMedia8" value="1" />
+        <ctl name="DISPLAY_PORT Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback bt-sco">
@@ -862,15 +862,15 @@
     </path>
 
     <path name="audio-ull-playback afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia8" value="1" />
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback usb-headphones">
-        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia8" value="1" />
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback usb-headset">
-        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia8" value="1" />
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback speaker-and-bt-sco">
@@ -3323,7 +3323,7 @@
     </path>
 
     <path name="audio-ull-playback bt-a2dp">
-        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia8" value="1" />
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="deep-buffer-playback speaker-and-bt-a2dp">


### PR DESCRIPTION
This patchset fixes the Ultra Low Latency usecase and re-enables
voice calls and any kind of VoIP through USBC-to-analog-3.5mm.